### PR TITLE
Feat: AI 광고 성과 분석 기능 추가 (Gemini API 연동) #28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
+++ b/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
@@ -3,17 +3,23 @@ package io.soyoung.addashboard.client;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 /**
  * Google Gemini API 호출 클라이언트. 프롬프트를 전송하고 텍스트 응답을 반환한다.
  */
+@Slf4j
 @Component
 public class GeminiApiClient {
+
+    private static final int MAX_RETRIES = 3;
+    private static final long INITIAL_DELAY_MS = 1000; // 첫 재시도 대기 1초
 
     private final RestClient restClient;
     private final String apiKey;
@@ -50,16 +56,48 @@ public class GeminiApiClient {
             )
         );
 
-        Map<String, Object> response = restClient.post()
-            .uri("/models/{model}:generateContent", model)
-            .header("Content-Type", "application/json")
-            .header("X-goog-api-key", apiKey)
-            .body(requestBody)
-            .retrieve()
-            .body(new ParameterizedTypeReference<>() {
-            });
+        return executeWithRetry(requestBody);
+    }
 
-        return extractText(response);
+    /**
+     * 429(Too Many Requests) 응답 시 지수 백오프로 재시도한다.
+     * 대기 시간: 1초 → 2초 → 4초 (2배씩 증가)
+     */
+    private String executeWithRetry(Map<String, Object> requestBody) {
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                Map<String, Object> response = restClient.post()
+                    .uri("/models/{model}:generateContent", model)
+                    .header("Content-Type", "application/json")
+                    .header("X-goog-api-key", apiKey)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<>() {
+                    });
+
+                return extractText(response);
+
+            } catch (HttpClientErrorException.TooManyRequests e) {
+                if (attempt == MAX_RETRIES) {
+                    throw e;
+                }
+                long delay = INITIAL_DELAY_MS * (1L << attempt); // 1초, 2초, 4초
+                log.warn("Gemini API 429 응답. {}ms 후 재시도 ({}/{})",
+                    delay, attempt + 1, MAX_RETRIES);
+                sleep(delay);
+            }
+        }
+
+        throw new IllegalStateException("Gemini API 재시도 횟수 초과");
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("재시도 대기 중 인터럽트 발생", e);
+        }
     }
 
     // Object -> List<Map<String, Object>> 로 캐스팅할 때 컴파일러가 경고

--- a/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
+++ b/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
@@ -1,9 +1,11 @@
 package io.soyoung.addashboard.client;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -20,8 +22,14 @@ public class GeminiApiClient {
     public GeminiApiClient(
         @Value("${gemini.api.key}") String apiKey,
         @Value("${gemini.api.model:gemini-2.0-flash}") String model) {
+
+        // 연결 타임아웃 5초, 읽기 타임아웃 30초
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory();
+        factory.setReadTimeout(Duration.ofSeconds(30));
+
         this.restClient = RestClient.builder()
             .baseUrl("https://generativelanguage.googleapis.com/v1beta")
+            .requestFactory(factory)
             .build();
         this.apiKey = apiKey;
         this.model = model;

--- a/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
+++ b/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
@@ -1,0 +1,88 @@
+package io.soyoung.addashboard.client;
+
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Google Gemini API 호출 클라이언트. 프롬프트를 전송하고 텍스트 응답을 반환한다.
+ */
+@Component
+public class GeminiApiClient {
+
+    private final RestClient restClient;
+    private final String apiKey;
+    private final String model;
+
+    public GeminiApiClient(
+        @Value("${gemini.api.key}") String apiKey,
+        @Value("${gemini.api.model:gemini-2.0-flash}") String model) {
+        this.restClient = RestClient.builder()
+            .baseUrl("https://generativelanguage.googleapis.com/v1beta")
+            .build();
+        this.apiKey = apiKey;
+        this.model = model;
+    }
+
+    /**
+     * Gemini API에 프롬프트를 전송하고 텍스트 응답을 반환한다.
+     *
+     * @param prompt 전송할 프롬프트
+     * @return Gemini가 생성한 텍스트 응답
+     */
+    public String generate(String prompt) {
+        Map<String, Object> requestBody = Map.of(
+            "contents", List.of(
+                Map.of("parts", List.of(
+                    Map.of("text", prompt)
+                ))
+            )
+        );
+
+        Map<String, Object> response = restClient.post()
+            .uri("/models/{model}:generateContent?key={key}", model, apiKey)
+            .header("Content-Type", "application/json")
+            .body(requestBody)
+            .retrieve()
+            .body(new ParameterizedTypeReference<>() {
+            });
+
+        return extractText(response);
+    }
+
+    // Object -> List<Map<String, Object>> 로 캐스팅할 때 컴파일러가 경고
+    // Gemini API 응답 구조는 이미 정해져있으므로 unchecked 경고 스킵하기 위해 어노테이션 사용
+    @SuppressWarnings("unchecked")
+    private String extractText(Map<String, Object> response) {
+        // candidates = Gemini가 생성한 응답 후보 목록
+        if (response == null || !response.containsKey("candidates")) {
+            return "";
+        }
+
+        List<Map<String, Object>> candidates =
+            (List<Map<String, Object>>) response.get("candidates");
+        if (candidates.isEmpty()) {
+            return "";
+        }
+
+        // parts = 하나의 응답이 여러 파트(텍스트, 이미지 등)로 구성될 수 있음
+        // 텍스트만 사용하므로 첫 번째 part의 text만 추출
+
+        Map<String, Object> content =
+            (Map<String, Object>) candidates.get(0).get("content");
+        if (content == null || !content.containsKey("parts")) {
+            return "";
+        }
+
+        List<Map<String, Object>> parts =
+            (List<Map<String, Object>>) content.get("parts");
+        if (parts.isEmpty()) {
+            return "";
+        }
+
+        return parts.get(0).getOrDefault("text", "").toString();
+    }
+}

--- a/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
+++ b/src/main/java/io/soyoung/addashboard/client/GeminiApiClient.java
@@ -51,8 +51,9 @@ public class GeminiApiClient {
         );
 
         Map<String, Object> response = restClient.post()
-            .uri("/models/{model}:generateContent?key={key}", model, apiKey)
+            .uri("/models/{model}:generateContent", model)
             .header("Content-Type", "application/json")
+            .header("X-goog-api-key", apiKey)
             .body(requestBody)
             .retrieve()
             .body(new ParameterizedTypeReference<>() {

--- a/src/main/java/io/soyoung/addashboard/config/JacksonConfig.java
+++ b/src/main/java/io/soyoung/addashboard/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package io.soyoung.addashboard.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/io/soyoung/addashboard/controller/StatsController.java
+++ b/src/main/java/io/soyoung/addashboard/controller/StatsController.java
@@ -5,7 +5,9 @@ import io.soyoung.addashboard.dto.CampaignSearchRequest;
 import io.soyoung.addashboard.dto.CampaignStatResponse;
 import io.soyoung.addashboard.dto.SummaryResponse;
 import io.soyoung.addashboard.dto.TrendResponse;
+import io.soyoung.addashboard.dto.AiAnalysisResponse;
 import io.soyoung.addashboard.service.AdService;
+import io.soyoung.addashboard.service.AiAnalysisService;
 import io.soyoung.addashboard.service.CampaignService;
 import io.soyoung.addashboard.service.DashboardService;
 import jakarta.validation.Valid;
@@ -17,6 +19,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,6 +36,7 @@ public class StatsController {
     private final DashboardService dashboardService;
     private final CampaignService campaignService;
     private final AdService adService;
+    private final AiAnalysisService aiAnalysisService;
 
     /**
      * 대시보드 종합 요약 통계를 조회한다.
@@ -87,5 +91,16 @@ public class StatsController {
         @RequestParam @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
         @RequestParam @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
         return ResponseEntity.ok(adService.getAdStats(campaignId, startDate, endDate));
+    }
+
+    /**
+     * AI 기반 광고 성과 종합 분석을 수행한다.
+     * 최근 7일간의 소재별 성과 데이터를 Gemini API로 분석하여 진단 및 개선 제안을 반환한다.
+     *
+     * @return AI 분석 결과
+     */
+    @PostMapping("/ai-analysis")
+    public ResponseEntity<AiAnalysisResponse> analyzeWithAi() {
+        return ResponseEntity.ok(aiAnalysisService.analyze());
     }
 }

--- a/src/main/java/io/soyoung/addashboard/dto/AiAnalysisResponse.java
+++ b/src/main/java/io/soyoung/addashboard/dto/AiAnalysisResponse.java
@@ -1,0 +1,33 @@
+package io.soyoung.addashboard.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * AI 광고 성과 분석 결과를 담는 응답 객체.
+ */
+@Getter
+@Builder
+public class AiAnalysisResponse {
+
+    private String overallDiagnosis;
+    private List<AdDiagnosis> adDiagnoses;
+    private List<String> actionItems;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    /**
+     * 개별 광고 소재에 대한 AI 진단 결과.
+     */
+    @Getter
+    @Builder
+    public static class AdDiagnosis {
+
+        private String adName;
+        private String campaignName;
+        private String diagnosis;
+        private String suggestion;
+    }
+}

--- a/src/main/java/io/soyoung/addashboard/service/AiAnalysisService.java
+++ b/src/main/java/io/soyoung/addashboard/service/AiAnalysisService.java
@@ -18,15 +18,12 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * AI 기반 광고 성과 분석 서비스.
- * 최근 7일간의 소재별 성과 데이터를 수집하여 Gemini API로 종합 분석을 수행한다.
+ * AI 기반 광고 성과 분석 서비스. 최근 7일간의 소재별 성과 데이터를 수집하여 Gemini API로 종합 분석을 수행한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -126,6 +123,7 @@ public class AiAnalysisService {
             .append("\n");
     }
 
+    // TODO: 프롬프트 외부 파일(txt)로 분리하여 관리
     private String buildPrompt(String adDataText, LocalDate startDate, LocalDate endDate) {
         return """
             너는 디지털 광고 성과 분석 전문가야.

--- a/src/main/java/io/soyoung/addashboard/service/AiAnalysisService.java
+++ b/src/main/java/io/soyoung/addashboard/service/AiAnalysisService.java
@@ -1,0 +1,210 @@
+package io.soyoung.addashboard.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.soyoung.addashboard.client.GeminiApiClient;
+import io.soyoung.addashboard.dto.AiAnalysisResponse;
+import io.soyoung.addashboard.dto.AiAnalysisResponse.AdDiagnosis;
+import io.soyoung.addashboard.entity.AdEntity;
+import io.soyoung.addashboard.entity.AdInsightRaw;
+import io.soyoung.addashboard.entity.EntityType;
+import io.soyoung.addashboard.repository.AdEntityRepository;
+import io.soyoung.addashboard.repository.AdInsightRawRepository;
+import io.soyoung.addashboard.repository.ConversionRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AI 기반 광고 성과 분석 서비스.
+ * 최근 7일간의 소재별 성과 데이터를 수집하여 Gemini API로 종합 분석을 수행한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiAnalysisService {
+
+    private final AdEntityRepository adEntityRepository;
+    private final AdInsightRawRepository adInsightRawRepository;
+    private final ConversionRepository conversionRepository;
+    private final GeminiApiClient geminiApiClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 최근 7일간의 광고 소재 성과를 AI로 분석한다.
+     *
+     * @return AI 분석 결과
+     */
+    public AiAnalysisResponse analyze() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(6);
+
+        String adDataText = collectAdData(startDate, endDate);
+        String prompt = buildPrompt(adDataText, startDate, endDate);
+        String response = geminiApiClient.generate(prompt);
+
+        return parseResponse(response, startDate, endDate);
+    }
+
+    /**
+     * 모든 캠페인의 소재별 성과 데이터를 텍스트로 수집한다.
+     */
+    private String collectAdData(LocalDate startDate, LocalDate endDate) {
+        List<AdEntity> campaigns = adEntityRepository.findAllByEntityType(EntityType.CAMPAIGN);
+        StringBuilder sb = new StringBuilder();
+
+        for (AdEntity campaign : campaigns) {
+            List<AdEntity> ads = adEntityRepository.findAllByParentMetaId(campaign.getMetaId());
+            if (ads.isEmpty()) {
+                continue;
+            }
+
+            sb.append("\n[캠페인: ").append(campaign.getName())
+                .append(" (유형: ").append(campaign.getAdCategory()).append(")]\n");
+
+            for (AdEntity ad : ads) {
+                appendAdStats(sb, ad, campaign.getMetaId(), startDate, endDate);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private void appendAdStats(StringBuilder sb, AdEntity ad, String campaignMetaId,
+        LocalDate startDate, LocalDate endDate) {
+        String metaId = ad.getMetaId();
+
+        List<AdInsightRaw> insights = adInsightRawRepository.findAllByMetaIdAndLogDateBetween(
+            metaId, startDate, endDate);
+
+        long totalImpressions = 0;
+        long totalSpend = 0;
+        long totalClicks = 0;
+
+        for (AdInsightRaw insight : insights) {
+            totalImpressions += insight.getImpressions() != null ? insight.getImpressions() : 0;
+            totalSpend += insight.getSpend() != null ? insight.getSpend().longValue() : 0;
+            totalClicks += insight.getClicks() != null ? insight.getClicks() : 0;
+        }
+
+        // 전환 수 집계
+        List<String> targetIds = new ArrayList<>();
+        targetIds.add(metaId);
+        adEntityRepository.findAllByParentMetaId(metaId).stream()
+            .map(AdEntity::getMetaId)
+            .forEach(targetIds::add);
+
+        int conversions = (int) conversionRepository.countByCampaignIdInAndCreatedAtBetween(
+            targetIds, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
+
+        double ctr = totalImpressions > 0
+            ? (double) totalClicks / totalImpressions * 100 : 0.0;
+        ctr = Math.round(ctr * 100.0) / 100.0;
+
+        String cpa = conversions > 0
+            ? BigDecimal.valueOf(totalSpend)
+            .divide(BigDecimal.valueOf(conversions), 0, RoundingMode.HALF_UP)
+            .toString() + "원"
+            : "전환 없음";
+
+        sb.append("  - 소재: ").append(ad.getName())
+            .append(" | 지출: ").append(totalSpend).append("원")
+            .append(" | 노출: ").append(totalImpressions)
+            .append(" | 클릭: ").append(totalClicks)
+            .append(" | CTR: ").append(ctr).append("%")
+            .append(" | 전환: ").append(conversions)
+            .append(" | CPA: ").append(cpa)
+            .append("\n");
+    }
+
+    private String buildPrompt(String adDataText, LocalDate startDate, LocalDate endDate) {
+        return """
+            너는 디지털 광고 성과 분석 전문가야.
+            아래는 %s ~ %s 기간의 광고 소재별 성과 데이터야.
+            이 데이터를 분석하여 반드시 아래 JSON 형식으로만 응답해줘.
+            JSON 외의 텍스트는 절대 포함하지 마.
+
+            데이터:
+            %s
+
+            응답 JSON 형식:
+            {
+              "overallDiagnosis": "전체 광고 계정의 성과를 종합적으로 진단한 내용",
+              "adDiagnoses": [
+                {
+                  "adName": "소재명",
+                  "campaignName": "캠페인명",
+                  "diagnosis": "해당 소재의 성과 진단",
+                  "suggestion": "구체적인 개선 제안"
+                }
+              ],
+              "actionItems": [
+                "즉시 실행할 수 있는 구체적인 액션 아이템 1",
+                "액션 아이템 2"
+              ]
+            }
+
+            분석 시 다음 사항을 고려해줘:
+            - CTR이 높지만 전환이 낮은 소재는 랜딩페이지 문제일 수 있음
+            - 지출이 있지만 전환이 0인 소재는 좀비 광고로 즉시 중단 권장
+            - CPA가 평균보다 현저히 높은 소재는 타겟팅 재검토 필요
+            - 성과가 좋은 소재의 특징을 파악하여 신규 소재 제작에 활용 제안
+            """.formatted(startDate, endDate, adDataText);
+    }
+
+    private AiAnalysisResponse parseResponse(String response, LocalDate startDate,
+        LocalDate endDate) {
+        try {
+            // Gemini가 코드블록으로 감쌀 경우 제거
+            String json = response.strip();
+            if (json.startsWith("```")) {
+                json = json.replaceFirst("```json\\s*", "").replaceFirst("```\\s*$", "");
+            }
+
+            JsonNode root = objectMapper.readTree(json);
+
+            String overallDiagnosis = root.path("overallDiagnosis").asText("");
+
+            List<AdDiagnosis> adDiagnoses = new ArrayList<>();
+            for (JsonNode node : root.path("adDiagnoses")) {
+                adDiagnoses.add(AdDiagnosis.builder()
+                    .adName(node.path("adName").asText(""))
+                    .campaignName(node.path("campaignName").asText(""))
+                    .diagnosis(node.path("diagnosis").asText(""))
+                    .suggestion(node.path("suggestion").asText(""))
+                    .build());
+            }
+
+            List<String> actionItems = new ArrayList<>();
+            for (JsonNode node : root.path("actionItems")) {
+                actionItems.add(node.asText());
+            }
+
+            return AiAnalysisResponse.builder()
+                .overallDiagnosis(overallDiagnosis)
+                .adDiagnoses(adDiagnoses)
+                .actionItems(actionItems)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+
+        } catch (JsonProcessingException e) {
+            return AiAnalysisResponse.builder()
+                .overallDiagnosis(response)
+                .adDiagnoses(List.of())
+                .actionItems(List.of())
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,8 @@ sync:
   cron:
     yesterday: "0 0 10 * * *"
     seven-days: "0 0 16 * * *"
+
+gemini:
+  api:
+    key: ${GEMINI_API_KEY}
+    model: gemini-2.0-flash

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,4 +30,5 @@ sync:
 gemini:
   api:
     key: ${GEMINI_API_KEY}
-    model: gemini-2.0-flash
+    model: gemini-flash-latest
+


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

closes #28 


 - Google Gemini API를 연동하여 최근 7일간 소재(Ad) 단위 성과 데이터를 AI로 종합        
  분석하는 기능 추가
  - POST /api/v1/stats/ai-analysis 엔드포인트를 통해 종합 진단, 소재별 진단, 액션        
  아이템을 반환
  - 429 응답 대비 지수 백오프 재시도(최대 3회) 및 읽기 타임아웃(30초) 설정

변경 사항

  - GeminiApiClient — Gemini API 호출 클라이언트 (X-goog-api-key 헤더 인증, 지수 백오프) 
  - AiAnalysisService — 소재별 데이터 수집, 프롬프트 구성, 응답 파싱
  - AiAnalysisResponse — 분석 결과 응답 DTO
  - StatsController — AI 분석 엔드포인트 추가
  - JacksonConfig — ObjectMapper 빈 등록
  - application.yml — Gemini API 설정 추가
  - build.gradle — jackson-databind 의존성 추가

  Test plan

  - POST /api/v1/stats/ai-analysis 호출 시 정상 응답 확인
  - 소재별 진단에 캠페인명, 소재명, 진단, 제안이 포함되는지 확인
  - 좀비 광고(전환 0건) 소재에 대한 중단 권장 진단 확인
  - Gemini API 장애 시 타임아웃 및 재시도 동작 확인
